### PR TITLE
Acid Generation Enhancement 3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx5G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html

--- a/src/main/java/io/github/randomkiddo/Chocolate.java
+++ b/src/main/java/io/github/randomkiddo/Chocolate.java
@@ -17,6 +17,7 @@ import io.github.randomkiddo.enchants.*;
 import io.github.randomkiddo.fluids.FluidRegistry;
 import io.github.randomkiddo.ores.IngotRegistry;
 import io.github.randomkiddo.ores.OreRegistry;
+import io.github.randomkiddo.worldgen.BiomeModificationsRegistry;
 import io.github.randomkiddo.worldgen.TreeRegistry;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
@@ -53,5 +54,6 @@ public class Chocolate implements ModInitializer {
 		ChocolateRegistry.register();
 		FluidRegistry.register();
 		TreeRegistry.register();
+		BiomeModificationsRegistry.register();
 	}
 }

--- a/src/main/java/io/github/randomkiddo/fluids/FluidRegistry.java
+++ b/src/main/java/io/github/randomkiddo/fluids/FluidRegistry.java
@@ -19,7 +19,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
-import net.minecraft.world.gen.feature.LakeFeature;
 
 /**
  * Registers all fluids for this mod
@@ -45,20 +44,17 @@ public class FluidRegistry {
      * @see AcidFluid
      */
     public static Block ACID;
-    @SuppressWarnings({ "deprecated" }) static LakeFeature ACID_LAKE; //todo lake generation
 
     /**
      * Registers all the fluid features above
      * @see Registry
      */
-    @SuppressWarnings({ "deprecated" }) public static void register() {
+    public static void register() {
         STILL_ACID = Registry.register(Registry.FLUID, new Identifier("chocolate", "still_acid"), new AcidFluid.Still());
         FLOWING_ACID = Registry.register(Registry.FLUID, new Identifier("chocolate", "flowing_acid"), new AcidFluid.Flowing());
         ACID_BUCKET = Registry.register(Registry.ITEM, new Identifier("chocolate", "acid_bucket"),
                 new BucketItem(STILL_ACID, new Item.Settings().recipeRemainder(Items.BUCKET).maxCount(1).group(Chocolate.CHOCOLATE_GROUP)));
         ACID = Registry.register(Registry.BLOCK, new Identifier("chocolate", "acid"),
                 new FluidBlock(STILL_ACID, FabricBlockSettings.copy(Blocks.WATER)));
-        //ACID_LAKE = Registry.register(Registry.FEATURE, new Identifier("chocolate", "acid_lake"),
-         //       new LakeFeature(SingleStateFeatureConfig::));
     }
 }

--- a/src/main/java/io/github/randomkiddo/worldgen/BiomeModificationsRegistry.java
+++ b/src/main/java/io/github/randomkiddo/worldgen/BiomeModificationsRegistry.java
@@ -1,0 +1,53 @@
+/**
+ * The Chocolate mod, repository, and source code is licensed under the GNU GPLv3 License
+ * For more information, see: https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ * Copyright © 2021 RandomKiddo
+ * Copyright © 2022 RandomKiddo
+ */
+
+package io.github.randomkiddo.worldgen;
+
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.ModificationPhase;
+import net.fabricmc.fabric.api.tag.convention.v1.ConventionalBiomeTags;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.RegistryEntry;
+import net.minecraft.world.gen.GenerationStep;
+import net.minecraft.world.gen.feature.*;
+import net.minecraft.world.gen.placementmodifier.BiomePlacementModifier;
+import net.minecraft.world.gen.placementmodifier.RarityFilterPlacementModifier;
+import net.minecraft.world.gen.stateprovider.BlockStateProvider;
+
+import static io.github.randomkiddo.fluids.FluidRegistry.ACID;
+
+/**
+ * Registers all vanilla biome modifications for this mod including: lakes
+ */
+public class BiomeModificationsRegistry {
+    /**
+     * The acid lake configured feature, uses deprecated LakeFeature class
+     * @see LakeFeature
+     * @see LakeFeature.Config
+     */
+    @SuppressWarnings({ "deprecated" })
+    public static final RegistryEntry<ConfiguredFeature<LakeFeature.Config, ?>> ACID_LAKE_CF = ConfiguredFeatures.register(
+            "chocolate:acid_lake", Feature.LAKE,
+            new LakeFeature.Config(BlockStateProvider.of(ACID.getDefaultState()), BlockStateProvider.of(ACID.getDefaultState())));
+    /**
+     * The placed feature for acid lakes
+     */
+    public static final RegistryEntry<PlacedFeature> ACID_LAKE_PF = PlacedFeatures.register(
+            "chocolate:acid_lake", ACID_LAKE_CF, RarityFilterPlacementModifier.of(80),
+            PlacedFeatures.WORLD_SURFACE_WG_HEIGHTMAP, BiomePlacementModifier.of());
+
+    /**
+     * Registers all related biome modification features above
+     */
+    public static void register() {
+        BiomeModifications.create(new Identifier("chocolate", "acid_lake")).add(ModificationPhase.ADDITIONS, (biomeSelectionContext) ->
+                biomeSelectionContext.hasTag(ConventionalBiomeTags.IN_THE_END), (biomeSelectionContext, biomeModificationContext) ->
+                biomeModificationContext.getGenerationSettings().addBuiltInFeature(GenerationStep.Feature.LAKES, ACID_LAKE_PF.value())
+        ); // Register and create acid lake
+    }
+}


### PR DESCRIPTION
Enhancements:
Allows Acid Generation in the end islands, as a part of the Tie Up Loose Ends Milestone

Additional Fixes:
Aided with grade ram allocation