### PR TITLE
Fix Missing Slime Boots Recipe

### DIFF
--- a/src/main/resources/data/chocolate/recipes/slime_boots.json
+++ b/src/main/resources/data/chocolate/recipes/slime_boots.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "   ",
+    "C C",
+    "C C"
+  ],
+  "key": {
+    "C": {
+      "item": "minecraft:slime_ball"
+    }
+  },
+  "result": {
+    "item": "chocolate:slime_boots",
+    "count": 1
+  }
+}


### PR DESCRIPTION
Bug Fixes:
None

Enhancements:
None

Additional Fixes/Additions:
Created missing slime boots recipe

Noticed during the creation of the wiki